### PR TITLE
Feature/day 01

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,24 +6,24 @@
 		"dockerfile": "Dockerfile",
 		// Choose variant: latest, vnc
 		// Set `vnc` to spin up noVNC services. Useful in GitHub Codespaces.
-		"args": { "VARIANT": "latest" }
+		"args": { "VARIANT": "vnc" }
 	},
 
 	// =======================================================================
 	// Uncomment to enable noVNC for GitHub Codespaces
 	// =======================================================================
 
-	// "forwardPorts": [6080],
-	// "overrideCommand": false,
-	// "containerEnv": {
-	// 	// Port for noVNC Web Client & WebSocket
-	// 	"NOVNC_PORT": "6080",
-	// 	// VNC port QEMU listens. Default to 5900 + <display number>
-	// 	// If you run QEMU with "-vnc :1", then VNC_PORT should be 5901.
-	// 	"VNC_PORT": "5900",
-	// 	// QEMU launch options. Used in `run_image.sh`
-	// 	"QEMU_OPTS": "-vnc :0"
-	// },
+	"forwardPorts": [6080],
+	"overrideCommand": false,
+	"containerEnv": {
+		// Port for noVNC Web Client & WebSocket
+		"NOVNC_PORT": "6080",
+		// VNC port QEMU listens. Default to 5900 + <display number>
+		// If you run QEMU with "-vnc :1", then VNC_PORT should be 5901.
+		"VNC_PORT": "5900",
+		// QEMU launch options. Used in `run_image.sh`
+		"QEMU_OPTS": "-vnc :0"
+	},
 
 
 	// =======================================================================

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+BOOTX64.EFI
+*.img

--- a/build_img.sh
+++ b/build_img.sh
@@ -1,0 +1,13 @@
+DISK_IMG="disk.img"
+EFI_FILE="BOOTX64.EFI"
+
+rm -f ${DISK_IMG}
+qemu-img create -f raw ${DISK_IMG} 200M
+mkfs.fat -n 'MIKAN OS' -s 2 -f 2 -R 32 -F 32 ${DISK_IMG}
+
+mkdir -p mnt
+sudo mount -o loop disk.img mnt
+sudo mkdir -p mnt/EFI/BOOT
+sudo cp src/${EFI_FILE} mnt/EFI/BOOT/BOOTX64.EFI
+sudo umount mnt
+

--- a/build_img.sh
+++ b/build_img.sh
@@ -10,4 +10,3 @@ sudo mount -o loop disk.img mnt
 sudo mkdir -p mnt/EFI/BOOT
 sudo cp src/${EFI_FILE} mnt/EFI/BOOT/BOOTX64.EFI
 sudo umount mnt
-

--- a/build_src.sh
+++ b/build_src.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd src
+make clean all

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+./build_src.sh
+
+./build_img.sh
+
+sudo qemu-system-x86_64 \
+    -drive if=pflash,file=$HOME/osbook/devenv/OVMF_CODE.fd \
+    -drive if=pflash,file=$HOME/osbook/devenv/OVMF_VARS.fd \
+    -hda disk.img \
+    -vnc :0

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,0 +1,23 @@
+CC = clang
+CFLAGS = \
+	-target x86_64-pc-win32-coff \
+	-mno-red-zone -fno-stack-protector \
+	-fshort-wchar \
+	-Wall
+LLD = lld-link
+LLDFLAGS = /subsystem:efi_application
+ENTRY = EfiMain
+TARGET = BOOTX64.EFI
+SRCS = hello.c
+OBJS = $(SRCS:.c=.o)
+
+$(TARGET): $(OBJS)
+	$(LLD) $(LLDFLAGS) /entry:$(ENTRY) /out:$@ $^
+
+$(OBJS): $(SRCS)
+	$(CC) $(CFLAGS) -c $(SRCS)
+
+all: $(OBJS) $(TARGET)
+
+clean:
+	rm -f $(OBJS) $(TARGET)

--- a/src/hello.c
+++ b/src/hello.c
@@ -1,0 +1,31 @@
+typedef unsigned short CHAR16;
+typedef unsigned long long EFI_STATUS;
+typedef void *EFI_HANDLE;
+
+struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
+typedef EFI_STATUS (*EFI_TEXT_STRING) (
+    struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *This,
+    CHAR16 *String
+);
+
+typedef struct _EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL
+{
+    void *dummy;
+    EFI_TEXT_STRING OutputString;
+} EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL;
+
+typedef struct
+{
+    char dummy[52];
+    EFI_HANDLE ConsoleOutHandle;
+    EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL *ConOut;
+} EFI_SYSTEM_TABLE;
+
+EFI_STATUS EfiMain(
+    EFI_HANDLE ImageHandle,
+    EFI_SYSTEM_TABLE *SytemTable
+) {
+    SytemTable->ConOut->OutputString(SytemTable->ConOut, L"Hello, world\n");
+    while (1);
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces a basic setup for building and running an EFI application, including updates to the development container configuration, build scripts, source code, and supporting files. The most significant changes involve enabling noVNC services, creating build scripts for compiling and running the EFI application, and adding a simple "Hello, world" EFI program.

### Development environment updates:
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L9-R26): Enabled noVNC by setting the `VARIANT` to `vnc` and uncommenting the configuration for `forwardPorts`, `overrideCommand`, and `containerEnv`. This allows the container to support graphical output via noVNC.

### Build system additions:
* [`build_img.sh`](diffhunk://#diff-aa5535c09f0d7fa403e75aab49082b379f3e8a0b936e9f2093f4301824c175dfR1-R12): Added a script to create a bootable disk image using `qemu-img` and `mkfs.fat`, mount it, and copy the EFI binary to the appropriate directory.
* [`build_src.sh`](diffhunk://#diff-315f1f607dc84cdb2ba0f05d5222e30d435dc5baa99c90abfe3698857a95295bR1-R4): Added a script to clean and build the source code using `make`.
* [`run.sh`](diffhunk://#diff-d31ce0453051853c17ba2a5225b3d1bfab548e095bab0967d6acfd1b3ce1b35dR1-R11): Added a script to automate the build process and launch the EFI application in QEMU with the required firmware and disk image.

### Source code updates:
* [`src/Makefile`](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685R1-R23): Added a Makefile to compile the EFI application using `clang` and `lld-link`, targeting the EFI subsystem. It defines build rules for creating the `BOOTX64.EFI` binary.
* [`src/hello.c`](diffhunk://#diff-046ef77846b793d2fc6c87ff2ccb9562af3ed71f2651a7d15e4b641be0fff439R1-R31): Added a simple EFI application that outputs "Hello, world" to the console using the EFI system table's text output protocol.